### PR TITLE
WIP - Deploy Aodh services, replacing Ceilometer Alarm

### DIFF
--- a/environments/opendaylight_l3.yaml
+++ b/environments/opendaylight_l3.yaml
@@ -1,0 +1,8 @@
+parameters:
+    #NeutronEnableL3Agent: false
+    NeutronEnableForceMetadata: true
+    OpenDaylightEnableL3: true
+    NeutronServicePlugins: "networking_odl.l3.l3_odl.OpenDaylightL3RouterPlugin"
+    ExtraConfig:
+      neutron_mechanism_drivers: ['opendaylight']
+      neutron_tenant_network_type: vxlan

--- a/network/endpoints/endpoint_map.yaml
+++ b/network/endpoints/endpoint_map.yaml
@@ -4,6 +4,9 @@ description: >
   A Map of OpenStack Endpoints
 
 parameters:
+  AodhApiVirtualIP:
+    type: string
+    default: ''
   CeilometerApiVirtualIP:
     type: string
     default: ''
@@ -43,6 +46,9 @@ parameters:
   EndpointMap:
     type: json
     default:
+      AodhAdmin: {protocol: 'http', port: '8042', host: 'IP_ADDRESS'}
+      AodhInternal: {protocol: 'http', port: '8042', host: 'IP_ADDRESS'}
+      AodhPublic: {protocol: 'http', port: '8042', host: 'IP_ADDRESS'}
       CeilometerAdmin: {protocol: 'http', port: '8777', host: 'IP_ADDRESS'}
       CeilometerInternal: {protocol: 'http', port: '8777', host: 'IP_ADDRESS'}
       CeilometerPublic: {protocol: 'http', port: '8777', host: 'IP_ADDRESS'}
@@ -82,6 +88,28 @@ parameters:
     description: The DNS name of this cloud. E.g. ci-overcloud.tripleo.org
 
 resources:
+
+  AodhInternal:
+    type: OS::TripleO::Endpoint
+    properties:
+      EndpointName: AodhInternal
+      EndpointMap: { get_param: EndpointMap }
+      CloudName: {get_param: CloudName}
+      IP: {get_param: AodhApiVirtualIP}
+  AodhPublic:
+    type: OS::TripleO::Endpoint
+    properties:
+      EndpointName: AodhPublic
+      EndpointMap: { get_param: EndpointMap }
+      CloudName: {get_param: CloudName}
+      IP: {get_param: PublicVirtualIP}
+  AodhAdmin:
+    type: OS::TripleO::Endpoint
+    properties:
+      EndpointName: AodhAdmin
+      EndpointMap: { get_param: EndpointMap }
+      CloudName: {get_param: CloudName}
+      IP: {get_param: AodhApiVirtualIP}
 
   CeilometerInternal:
     type: OS::TripleO::Endpoint
@@ -407,6 +435,9 @@ resources:
 outputs:
   endpoint_map:
     value:
+      AodhInternal: {get_attr: [ AodhInternal, endpoint] }
+      AodhPublic: {get_attr: [ AodhPublic, endpoint] }
+      AodhAdmin: {get_attr: [ AodhAdmin, endpoint] }
       CeilometerInternal: {get_attr: [ CeilometerInternal, endpoint] }
       CeilometerPublic: {get_attr: [ CeilometerPublic, endpoint] }
       CeilometerAdmin: {get_attr: [ CeilometerAdmin, endpoint] }

--- a/overcloud-without-mergepy.yaml
+++ b/overcloud-without-mergepy.yaml
@@ -15,6 +15,11 @@ parameters:
     description: The password for the keystone admin account, used for monitoring, querying neutron etc.
     type: string
     hidden: true
+  AodhPassword:
+    default: unset
+    description: The password for the aodh services
+    type: string
+    hidden: true
   CeilometerBackend:
     default: 'mongodb'
     description: The ceilometer backend type.
@@ -600,6 +605,7 @@ parameters:
     default:
       NeutronTenantNetwork: tenant
       CeilometerApiNetwork: internal_api
+      AodhApiNetwork: internal_api
       MongoDbNetwork: internal_api
       CinderApiNetwork: internal_api
       CinderIscsiNetwork: storage
@@ -799,6 +805,7 @@ resources:
     properties:
       CloudName: {get_param: CloudName}
       CeilometerApiVirtualIP: {get_attr: [VipMap, net_ip_map, {get_param: [ServiceNetMap, CeilometerApiNetwork]}]}
+      AodhApiVirtualIP: {get_attr: [VipMap, net_ip_map, {get_param: [ServiceNetMap, AodhApiNetwork]}]}
       CinderApiVirtualIP: {get_attr: [VipMap, net_ip_map, {get_param: [ServiceNetMap, CinderApiNetwork]}]}
       GlanceApiVirtualIP: {get_attr: [VipMap, net_ip_map, {get_param: [ServiceNetMap, GlanceApiNetwork]}]}
       GlanceRegistryVirtualIP: {get_attr: [VipMap, net_ip_map, {get_param: [ServiceNetMap, GlanceRegistryNetwork]}]}
@@ -844,6 +851,7 @@ resources:
         properties:
           AdminPassword: {get_param: AdminPassword}
           AdminToken: {get_param: AdminToken}
+          AodhPassword: {get_param: AodhPassword}
           CeilometerBackend: {get_param: CeilometerBackend}
           CeilometerMeteringSecret: {get_param: CeilometerMeteringSecret}
           CeilometerPassword: {get_param: CeilometerPassword}
@@ -947,6 +955,7 @@ resources:
           ServiceNetMap: {get_param: ServiceNetMap}
           EndpointMap: {get_attr: [EndpointMap, endpoint_map]}
           CeilometerApiVirtualIP: {get_attr: [VipMap, net_ip_map, {get_param: [ServiceNetMap, CeilometerApiNetwork]}]}
+          AodhApiVirtualIP: {get_attr: [VipMap, net_ip_map, {get_param: [ServiceNetMap, AodhApiNetwork]}]}
           CinderApiVirtualIP: {get_attr: [VipMap, net_ip_map, {get_param: [ServiceNetMap, CinderApiNetwork]}]}
           HeatApiVirtualIP: {get_attr: [VipMap, net_ip_map, {get_param: [ServiceNetMap, HeatApiNetwork]}]}
           GlanceApiVirtualIP: {get_attr: [VipMap, net_ip_map, {get_param: [ServiceNetMap, GlanceApiNetwork]}]}
@@ -1154,6 +1163,7 @@ resources:
       heat_api_node_ips: {get_attr: [ControllerIpListMap, net_ip_map, {get_param: [ServiceNetMap, HeatApiNetwork]}]}
       swift_proxy_node_ips: {get_attr: [ControllerIpListMap, net_ip_map, {get_param: [ServiceNetMap, SwiftProxyNetwork]}]}
       ceilometer_api_node_ips: {get_attr: [ControllerIpListMap, net_ip_map, {get_param: [ServiceNetMap, CeilometerApiNetwork]}]}
+      aodh_api_node_ips: {get_attr: [ControllerIpListMap, net_ip_map, {get_param: [ServiceNetMap, AodhApiNetwork]}]}
       nova_api_node_ips: {get_attr: [ControllerIpListMap, net_ip_map, {get_param: [ServiceNetMap, NovaApiNetwork]}]}
       nova_metadata_node_ips: {get_attr: [ControllerIpListMap, net_ip_map, {get_param: [ServiceNetMap, NovaMetadataNetwork]}]}
       glance_api_node_ips: {get_attr: [ControllerIpListMap, net_ip_map, {get_param: [ServiceNetMap, GlanceApiNetwork]}]}
@@ -1262,6 +1272,7 @@ resources:
         nova_api_vip: {get_attr: [VipMap, net_ip_map, {get_param: [ServiceNetMap, NovaApiNetwork]}]}
         nova_metadata_vip: {get_attr: [VipMap, net_ip_map, {get_param: [ServiceNetMap, NovaMetadataNetwork]}]}
         ceilometer_api_vip: {get_attr: [VipMap, net_ip_map, {get_param: [ServiceNetMap, CeilometerApiNetwork]}]}
+        aodh_api_vip: {get_attr: [VipMap, net_ip_map, {get_param: [ServiceNetMap, AodhApiNetwork]}]}
         heat_api_vip: {get_attr: [VipMap, net_ip_map, {get_param: [ServiceNetMap, HeatApiNetwork]}]}
         horizon_vip: {get_attr: [VipMap, net_ip_map, {get_param: [ServiceNetMap, HorizonNetwork]}]}
         redis_vip: {get_attr: [RedisVirtualIP, ip_address]}
@@ -1507,6 +1518,9 @@ outputs:
   PublicVip:
     description: Controller VIP for public API endpoints
     value: {get_attr: [PublicVirtualIP, ip_address]}
+  AodhInternalVip:
+    description: VIP for Aodh API internal endpoint
+    value: {get_attr: [VipMap, net_ip_map, {get_param: [ServiceNetMap, AodhApiNetwork]}]}
   CeilometerInternalVip:
     description: VIP for Ceilometer API internal endpoint
     value: {get_attr: [VipMap, net_ip_map, {get_param: [ServiceNetMap, CeilometerApiNetwork]}]}

--- a/overcloud-without-mergepy.yaml
+++ b/overcloud-without-mergepy.yaml
@@ -113,6 +113,10 @@ parameters:
     default: ''
     type: string
     description: Neutron ID for ctlplane network.
+  NeutronEnableForceMetadata:
+    default: 'False'
+    description: If True, DHCP always provides metadata route to VM.
+    type: string
   NeutronEnableTunnelling:
     type: string
     default: "True"
@@ -231,6 +235,10 @@ parameters:
     default: 8081
     description: Set opendaylight service port
     type: number
+  OpenDaylightEnableL3:
+    description: Knob to enable/disable ODL L3
+    type: string
+    default: 'no'
   OpenDaylightInstall:
     default: false
     description: Whether to install OpenDaylight on the control nodes.
@@ -818,6 +826,7 @@ resources:
           OpenDaylightPort: {get_param: OpenDaylightPort}
           OpenDaylightUsername: {get_param: OpenDaylightUsername}
           OpenDaylightPassword: {get_param: OpenDaylightPassword}
+          OpenDaylightEnableL3: {get_param: OpenDaylightEnableL3}
           OpenDaylightHostname:
             str_replace:
               template: {get_param: OpenDaylightHostnameFormat}
@@ -886,6 +895,7 @@ resources:
           NeutronBridgeMappings: {get_param: NeutronBridgeMappings}
           NeutronExternalNetworkBridge: {get_param: NeutronExternalNetworkBridge}
           NeutronEnableTunnelling: {get_param: NeutronEnableTunnelling}
+          NeutronEnableForceMetadata: {get_param: NeutronEnableForceMetadata}
           NeutronNetworkVLANRanges: {get_param: NeutronNetworkVLANRanges}
           NeutronPublicInterface: {get_param: NeutronPublicInterface}
           NeutronPublicInterfaceDefaultRoute: {get_param: NeutronPublicInterfaceDefaultRoute}
@@ -911,6 +921,7 @@ resources:
           OpenDaylightInstall: {get_param: OpenDaylightInstall}
           OpenDaylightUsername: {get_param: OpenDaylightUsername}
           OpenDaylightPassword: {get_param: OpenDaylightPassword}
+          OpenDaylightEnableL3: {get_param: OpenDaylightEnableL3}
           PcsdPassword: {get_resource: PcsdPassword}
           PublicVirtualInterface: {get_param: PublicVirtualInterface}
           RabbitPassword: {get_param: RabbitPassword}

--- a/puppet/all-nodes-config.yaml
+++ b/puppet/all-nodes-config.yaml
@@ -36,6 +36,8 @@ parameters:
     type: comma_delimited_list
   ceilometer_api_node_ips:
     type: comma_delimited_list
+  aodh_api_node_ips:
+    type: comma_delimited_list
   nova_api_node_ips:
     type: comma_delimited_list
   nova_metadata_node_ips:
@@ -172,6 +174,14 @@ resources:
                         list_join:
                         - "','"
                         - {get_param: ceilometer_api_node_ips}
+                aodh_api_node_ips:
+                  str_replace:
+                    template: "['SERVERS_LIST']"
+                    params:
+                      SERVERS_LIST:
+                        list_join:
+                        - "','"
+                        - {get_param: aodh_api_node_ips}
                 nova_api_node_ips:
                   str_replace:
                     template: "['SERVERS_LIST']"

--- a/puppet/compute.yaml
+++ b/puppet/compute.yaml
@@ -337,6 +337,11 @@ resources:
     properties:
       ControlPlaneIP: {get_attr: [NovaCompute, networks, ctlplane, 0]}
 
+  ExternalPort:
+    type: OS::TripleO::Controller::Ports::ExternalPort
+    properties:
+      ControlPlaneIP: {get_attr: [NovaCompute, networks, ctlplane, 0]}
+
   NetIpMap:
     type: OS::TripleO::Network::Ports::NetIpMap
     properties:
@@ -344,6 +349,7 @@ resources:
       InternalApiIp: {get_attr: [InternalApiPort, ip_address]}
       StorageIp: {get_attr: [StoragePort, ip_address]}
       TenantIp: {get_attr: [TenantPort, ip_address]}
+      ExternalIp: {get_attr: [ExternalPort, ip_address]}
 
   NetworkConfig:
     type: OS::TripleO::Compute::Net::SoftwareConfig
@@ -352,6 +358,7 @@ resources:
       InternalApiIpSubnet: {get_attr: [InternalApiPort, ip_subnet]}
       StorageIpSubnet: {get_attr: [StoragePort, ip_subnet]}
       TenantIpSubnet: {get_attr: [TenantPort, ip_subnet]}
+      ExternalIpSubnet: {get_attr: [ExternalPort, ip_subnet]}
 
   NetworkDeployment:
     type: OS::TripleO::SoftwareDeployment
@@ -595,6 +602,9 @@ outputs:
   tenant_ip_address:
     description: IP address of the server in the tenant network
     value: {get_attr: [TenantPort, ip_address]}
+  external_ip_address:
+    description: IP address of the server in the external network
+    value: {get_attr: [ExternalPort, ip_address]}
   hostname:
     description: Hostname of the server
     value: {get_attr: [NovaCompute, name]}

--- a/puppet/controller.yaml
+++ b/puppet/controller.yaml
@@ -14,6 +14,14 @@ parameters:
     description: The keystone auth secret and db password.
     type: string
     hidden: true
+  AodhApiVirtualIP:
+    type: string
+    default: ''
+  AodhPassword:
+    default: unset
+    description: The password for the aodh services.
+    type: string
+    hidden: true
   CeilometerApiVirtualIP:
     type: string
     default: ''
@@ -915,6 +923,7 @@ resources:
         ceilometer_backend: {get_param: CeilometerBackend}
         ceilometer_metering_secret: {get_param: CeilometerMeteringSecret}
         ceilometer_password: {get_param: CeilometerPassword}
+        aodh_password: {get_param: AodhPassword}
         ceilometer_coordination_url:
           list_join:
             - ''
@@ -927,6 +936,12 @@ resources:
             - - 'mysql://ceilometer:unset@'
               - {get_param: MysqlVirtualIP}
               - '/ceilometer'
+        ceilometer_public_url: {get_param: [EndpointMap, CeilometerPublic, uri]}
+        ceilometer_internal_url: {get_param: [EndpointMap, CeilometerInternal, uri]}
+        ceilometer_admin_url: {get_param: [EndpointMap, CeilometerAdmin, uri]}
+        aodh_public_url: {get_param: [EndpointMap, AodhPublic, uri]}
+        aodh_internal_url: {get_param: [EndpointMap, AodhInternal, uri]}
+        aodh_admin_url: {get_param: [EndpointMap, AodhAdmin, uri]}
         snmpd_readonly_user_name: {get_param: SnmpdReadonlyUserName}
         snmpd_readonly_user_password: {get_param: SnmpdReadonlyUserPassword}
         nova_password: {get_param: NovaPassword}
@@ -984,6 +999,7 @@ resources:
         neutron_api_network: {get_attr: [NetIpMap, net_ip_map, {get_param: [ServiceNetMap, NeutronApiNetwork]}]}
         neutron_local_ip: {get_attr: [NetIpMap, net_ip_map, {get_param: [ServiceNetMap, NeutronTenantNetwork]}]}
         ceilometer_api_network: {get_attr: [NetIpMap, net_ip_map, {get_param: [ServiceNetMap, CeilometerApiNetwork]}]}
+        aodh_api_network: {get_attr: [NetIpMap, net_ip_map, {get_param: [ServiceNetMap, AodhApiNetwork]}]}
         nova_api_network: {get_attr: [NetIpMap, net_ip_map, {get_param: [ServiceNetMap, NovaApiNetwork]}]}
         nova_metadata_network: {get_attr: [NetIpMap, net_ip_map, {get_param: [ServiceNetMap, NovaMetadataNetwork]}]}
         horizon_network: {get_attr: [NetIpMap, net_ip_map, {get_param: [ServiceNetMap, HorizonNetwork]}]}
@@ -1178,7 +1194,7 @@ resources:
                 opendaylight_username: {get_input: opendaylight_username}
                 opendaylight_password: {get_input: opendaylight_password}
                 opendaylight_enable_l3: {get_input: opendaylight_enable_l3}
-                
+
                 # ONOS
                 onos_port: {get_input: onos_port}
 
@@ -1244,6 +1260,27 @@ resources:
                 ceilometer::db::mysql::password: {get_input: ceilometer_password}
                 snmpd_readonly_user_name: {get_input: snmpd_readonly_user_name}
                 snmpd_readonly_user_password: {get_input: snmpd_readonly_user_password}
+
+                # Aodh
+                aodh::rabbit_userid: {get_input: rabbit_username}
+                aodh::rabbit_password: {get_input: rabbit_password}
+                aodh::rabbit_use_ssl: {get_input: rabbit_client_use_ssl}
+                aodh::rabbit_port: {get_input: rabbit_client_port}
+                aodh::debug: {get_input: debug}
+                aodh::wsgi::apache::ssl: false
+                aodh::api::service_name: 'httpd'
+                aodh::api::host: {get_input: aodh_api_network}
+                aodh::api::keystone_password: {get_input: aodh_password}
+                aodh::api::keystone_auth_uri: {get_input: keystone_auth_uri}
+                aodh::api::keystone_identity_uri: {get_input: keystone_identity_uri}
+                aodh::auth::auth_password: {get_input: aodh_password}
+                aodh::keystone::auth::public_url: {get_input: aodh_public_url }
+                aodh::keystone::auth::internal_url: {get_input: aodh_internal_url }
+                aodh::keystone::auth::admin_url: {get_input: aodh_admin_url }
+                aodh::keystone::auth::password: {get_input: aodh_password }
+                aodh::keystone::auth::region: {get_input: keystone_region}
+                # for a migration path from ceilometer-alarm to aodh, we use the same database & coordination
+                aodh::evaluator::coordination_url: {get_input: ceilometer_coordination_url}
 
                 # Nova
                 nova::rabbit_userid: {get_input: rabbit_username}

--- a/puppet/controller.yaml
+++ b/puppet/controller.yaml
@@ -357,6 +357,10 @@ parameters:
     default: 'True'
     description: Allow automatic l3-agent failover
     type: string
+  NeutronEnableForceMetadata:
+    default: 'False'
+    description: If True, DHCP always provides metadata route to VM.
+    type: string
   NeutronEnableTunnelling:
     type: string
     default: "True"
@@ -460,6 +464,10 @@ parameters:
     type: string
     description: The password for the opendaylight server.
     hidden: true
+  OpenDaylightEnableL3:
+    description: Knob to enable/disable ODL L3
+    type: string
+    default: 'no'
   ONOSPort:
     default: 8181
     description: Set onos service port
@@ -717,6 +725,7 @@ resources:
       input_values:
         bootstack_nodeid: {get_attr: [Controller, name]}
         neutron_enable_tunneling: {get_param: NeutronEnableTunnelling}
+        neutron_enable_force_metadata: {get_param: NeutronEnableForceMetadata}
         haproxy_log_address: {get_param: HAProxySyslogAddress}
         heat.watch_server_url:
           list_join:
@@ -830,6 +839,7 @@ resources:
         opendaylight_install: {get_param: OpenDaylightInstall}
         opendaylight_username: {get_param: OpenDaylightUsername}
         opendaylight_password: {get_param: OpenDaylightPassword}
+        opendaylight_enable_l3: {get_param: OpenDaylightEnableL3}
         onos_port: {get_param: ONOSPort}
         neutron_flat_networks: {get_param: NeutronFlatNetworks}
         neutron_metadata_proxy_shared_secret: {get_param: NeutronMetadataProxySharedSecret}
@@ -1167,6 +1177,7 @@ resources:
                 opendaylight_install: {get_input: opendaylight_install}
                 opendaylight_username: {get_input: opendaylight_username}
                 opendaylight_password: {get_input: opendaylight_password}
+                opendaylight_enable_l3: {get_input: opendaylight_enable_l3}
                 
                 # ONOS
                 onos_port: {get_input: onos_port}
@@ -1187,6 +1198,7 @@ resources:
                 neutron_flat_networks: {get_input: neutron_flat_networks}
                 neutron::agents::metadata::shared_secret: {get_input: neutron_metadata_proxy_shared_secret}
                 neutron::agents::metadata::metadata_ip: {get_input: neutron_api_network}
+                neutron::agents::dhcp::enable_force_metadata: {get_input: neutron_enable_force_metadata}
                 neutron_agent_mode: {get_input: neutron_agent_mode}
                 neutron_router_distributed: {get_input: neutron_router_distributed}
                 neutron::core_plugin: {get_input: neutron_core_plugin}

--- a/puppet/hieradata/common.yaml
+++ b/puppet/hieradata/common.yaml
@@ -6,6 +6,7 @@ ceilometer::agent::auth::auth_region: 'regionOne'
 # FIXME: Might be better to use 'service' tenant here but this requires
 # changes in the tripleo-incubator keystone role setup
 ceilometer::agent::auth::auth_tenant_name: 'admin'
+aodh::auth::auth_tenant_name: 'admin'
 
 nova::network::neutron::neutron_admin_tenant_name: 'service'
 nova::network::neutron::neutron_admin_username: 'neutron'

--- a/puppet/hieradata/controller.yaml
+++ b/puppet/hieradata/controller.yaml
@@ -32,6 +32,7 @@ redis::sentinel::notification_script: '/usr/local/bin/redis-notifications.sh'
 # service tenant
 nova::api::admin_tenant_name: 'service'
 glance::api::keystone_tenant: 'service'
+aodh::api::keystone_tenant: 'service'
 glance::registry::keystone_tenant: 'service'
 neutron::server::auth_tenant: 'service'
 neutron::agents::metadata::auth_tenant: 'service'
@@ -39,6 +40,7 @@ cinder::api::keystone_tenant: 'service'
 swift::proxy::authtoken::admin_tenant_name: 'service'
 ceilometer::api::keystone_tenant: 'service'
 heat::keystone_tenant: 'service'
+aodh::keystone::auth::tenant: 'service'
 
 # keystone
 keystone::cron::token_flush::maxdelay: 3600
@@ -115,6 +117,7 @@ tripleo::loadbalancer::mysql: true
 tripleo::loadbalancer::redis: true
 tripleo::loadbalancer::swift_proxy_server: true
 tripleo::loadbalancer::ceilometer: true
+tripleo::loadbalancer::aodh: true
 tripleo::loadbalancer::heat_api: true
 tripleo::loadbalancer::heat_cloudwatch: true
 tripleo::loadbalancer::heat_cfn: true

--- a/puppet/manifests/overcloud_controller_pacemaker.pp
+++ b/puppet/manifests/overcloud_controller_pacemaker.pp
@@ -713,7 +713,11 @@ if hiera('step') >= 3 {
   if hiera('neutron_enable_bigswitch_ml2', false) {
     include ::neutron::plugins::ml2::bigswitch::restproxy
   }
+<<<<<<< HEAD
   if !('onos_ml2' in hiera('neutron_mechanism_drivers') or str2bool(hiera('opendaylight_enable_l3', 'no'))) {
+=======
+  if !('onos_ml2' in hiera('neutron_mechanism_drivers')) {
+>>>>>>> 0fd1575... Adds current opnfv patch with ODL and ONOS support
     neutron_l3_agent_config {
       'DEFAULT/ovs_use_veth': value => hiera('neutron_ovs_use_veth', false);
     }
@@ -945,6 +949,33 @@ if hiera('step') >= 3 {
     enabled        => false,
   }
   class { '::heat::engine' :
+    manage_service => false,
+    enabled        => false,
+  }
+
+  # Aodh
+  include ::aodh
+  include ::aodh::config
+  include ::aodh::auth
+  include ::aodh::client
+  include ::aodh::wsgi::apache
+  class { '::aodh::api':
+    manage_service => false,
+    enabled        => false,
+    service_name   => 'httpd',
+  }
+  class { '::aodh::wsgi::apache':
+    ssl => false,
+  }
+  class { '::aodh::evaluator':
+    manage_service => false,
+    enabled        => false,
+  }
+  class { '::aodh::notifier':
+    manage_service => false,
+    enabled        => false,
+  }
+  class { '::aodh::listener':
     manage_service => false,
     enabled        => false,
   }
@@ -1219,7 +1250,11 @@ if hiera('step') >= 4 {
                     Pacemaker::Resource::Service["${::neutron::params::dhcp_agent_service}"]],
       }
     }
+<<<<<<< HEAD
     if !('onos_ml2' in hiera('neutron_mechanism_drivers') or str2bool(hiera('opendaylight_enable_l3', 'no'))) {
+=======
+    if !('onos_ml2' in hiera('neutron_mechanism_drivers')) {
+>>>>>>> 0fd1575... Adds current opnfv patch with ODL and ONOS support
       pacemaker::constraint::base { 'neutron-dhcp-agent-to-l3-agent-constraint':
         constraint_type => 'order',
         first_resource  => "${::neutron::params::dhcp_agent_service}-clone",
@@ -1251,7 +1286,11 @@ if hiera('step') >= 4 {
         score   => 'INFINITY',
         require => [Pacemaker::Resource::Service[$::neutron::params::l3_agent_service],
                     Pacemaker::Resource::Service[$::neutron::params::metadata_agent_service]],
+<<<<<<< HEAD
       }
+=======
+     }
+>>>>>>> 0fd1575... Adds current opnfv patch with ODL and ONOS support
     }
     # Nova
     pacemaker::resource::service { $::nova::params::api_service_name :
@@ -1350,7 +1389,7 @@ if hiera('step') >= 4 {
                   Pacemaker::Resource::Service[$::nova::params::conductor_service_name]],
     }
 
-    # Ceilometer
+    # Ceilometer and Aodh
     case downcase(hiera('ceilometer_backend')) {
       /mysql/: {
         pacemaker::resource::service { $::ceilometer::params::agent_central_service_name :
@@ -1378,6 +1417,15 @@ if hiera('step') >= 4 {
     pacemaker::resource::service { $::ceilometer::params::alarm_notifier_service_name :
       clone_params => 'interleave=true',
     }
+    pacemaker::resource::service { $::aodh::params::notifier_service_name :
+      clone_params => 'interleave=true',
+    }
+    pacemaker::resource::service { $::aodh::params::expirer_service_name :
+      clone_params => 'interleave=true',
+    }
+    pacemaker::resource::service { $::aodh::params::listener_service_name :
+      clone_params => 'interleave=true',
+    }
     pacemaker::resource::service { $::ceilometer::params::agent_notification_service_name :
       clone_params => 'interleave=true',
     }
@@ -1389,8 +1437,10 @@ if hiera('step') >= 4 {
     # Fedora doesn't know `require-all` parameter for constraints yet
     if $::operatingsystem == 'Fedora' {
       $redis_ceilometer_constraint_params = undef
+      $redis_aodh_constraint_params = undef
     } else {
       $redis_ceilometer_constraint_params = 'require-all=false'
+      $redis_aodh_constraint_params = 'require-all=false'
     }
     pacemaker::constraint::base { 'redis-then-ceilometer-central-constraint':
       constraint_type   => 'order',
@@ -1401,6 +1451,16 @@ if hiera('step') >= 4 {
       constraint_params => $redis_ceilometer_constraint_params,
       require           => [Pacemaker::Resource::Ocf['redis'],
                             Pacemaker::Resource::Service[$::ceilometer::params::agent_central_service_name]],
+    }
+    pacemaker::constraint::base { 'redis-then-aodh-evaluator-constraint':
+      constraint_type   => 'order',
+      first_resource    => 'redis-master',
+      second_resource   => "${::aodh::params::evaluator_service_name}-clone",
+      first_action      => 'promote',
+      second_action     => 'start',
+      constraint_params => $redis_aodh_constraint_params,
+      require           => [Pacemaker::Resource::Ocf['redis'],
+                            Pacemaker::Resource::Service[$::aodh::params::evaluator_service_name]],
     }
     pacemaker::constraint::base { 'keystone-then-ceilometer-central-constraint':
       constraint_type => 'order',
@@ -1499,6 +1559,38 @@ if hiera('step') >= 4 {
       score   => 'INFINITY',
       require => [Pacemaker::Resource::Service[$::ceilometer::params::agent_notification_service_name],
                   Pacemaker::Resource::Service[$::ceilometer::params::alarm_notifier_service_name]],
+    }
+    pacemaker::constraint::base { 'aodh-delay-then-aodh-evaluator-constraint':
+      constraint_type => 'order',
+      first_resource  => 'delay-clone',
+      second_resource => "${::aodh::params::evaluator_service_name}-clone",
+      first_action    => 'start',
+      second_action   => 'start',
+      require         => [Pacemaker::Resource::Service[$::aodh::params::evaluator_service_name],
+                          Pacemaker::Resource::Ocf['delay']],
+    }
+    pacemaker::constraint::colocation { 'aodh-evaluator-with-aodh-delay-colocation':
+      source  => "${::aodh::params::evaluator_service_name}-clone",
+      target  => 'delay-clone',
+      score   => 'INFINITY',
+      require => [Pacemaker::Resource::Service[$::horizon::params::http_service],
+                  Pacemaker::Resource::Ocf['delay']],
+    }
+    pacemaker::constraint::base { 'aodh-evaluator-then-aodh-notifier-constraint':
+      constraint_type => 'order',
+      first_resource  => "${::aodh::params::evaluator_service_name}-clone",
+      second_resource => "${::aodh::params::notifier_service_name}-clone",
+      first_action    => 'start',
+      second_action   => 'start',
+      require         => [Pacemaker::Resource::Service[$::aodh::params::evaluator_service_name],
+                          Pacemaker::Resource::Service[$::aodh::params::notifier_service_name]],
+    }
+    pacemaker::constraint::colocation { 'aodh-notifier-with-aodh-evaluator-colocation':
+      source  => "${::aodh::params::notifier_service_name}-clone",
+      target  => "${::aodh::params::evaluator_service_name}-clone",
+      score   => 'INFINITY',
+      require => [Pacemaker::Resource::Service[$::aodh::params::evaluator_service_name],
+                  Pacemaker::Resource::Service[$::aodh::params::notifier_service_name]],
     }
     if downcase(hiera('ceilometer_backend')) == 'mongodb' {
       pacemaker::constraint::base { 'mongodb-then-ceilometer-central-constraint':

--- a/puppet/manifests/overcloud_opendaylight.pp
+++ b/puppet/manifests/overcloud_opendaylight.pp
@@ -22,5 +22,6 @@ if count(hiera('ntp::servers')) > 0 {
 class {"opendaylight":
   extra_features => ['odl-ovsdb-openstack'],
   odl_rest_port  => hiera('opendaylight_port'),
+  enable_l3      => hiera('opendaylight_enable_l3', 'no'),
 }
 

--- a/puppet/opendaylight-puppet.yaml
+++ b/puppet/opendaylight-puppet.yaml
@@ -25,6 +25,10 @@ parameters:
     description: The admin password for the OpenDaylight node
     type: string
     hidden: true
+  OpenDaylightEnableL3:
+    description: Knob to enable/disable ODL L3
+    type: string
+    default: 'no'
   OpenDaylightPort:
     default: 8081
     description: Set OpenDaylight service port
@@ -123,6 +127,9 @@ resources:
             params:
               server: {get_param: NtpServer}
         opendaylight_port: {get_param: OpenDaylightPort}
+        opendaylight_enable_l3: {get_param: OpenDaylightEnableL3}
+        opendaylight_username: {get_param: OpenDaylightUsername}
+        opendaylight_password: {get_param: OpenDaylightPassword}
 
   OpenDaylightConfig:
     type: OS::Heat::StructuredConfig
@@ -147,6 +154,7 @@ resources:
                 opendaylight::admin_username: {get_param: OpenDaylightUsername}
                 opendaylight::admin_password: {get_param: OpenDaylightPassword}
                 opendaylight_port: {get_input: opendaylight_port}
+                opendaylight_enable_l3: {get_input: opendaylight_enable_l3}
             ceph:
               raw_data: {get_file: hieradata/ceph.yaml}
 


### PR DESCRIPTION
Ceilometer Alarm is deprecated in Liberty by Aodh.

This patch:
- manage Aodh Keystone resources
- deploy Aodh API under WSGI, Notifier, Listener and Evaluator
- manage new parameters to customize Aodh deployment
- uses ceilometer DB for the upgrade path

WIP - pacemaker work needs to be finished.

Change-Id: I58d419173e80d2462accf7324c987c71420fd5f6

Conflicts:
    overcloud.yaml
    puppet/controller.yaml
    puppet/hieradata/controller.yaml
    puppet/manifests/overcloud_controller.pp
    puppet/manifests/overcloud_controller_pacemaker.pp
